### PR TITLE
Use Blazor 0.8.0 preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,4 +65,12 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
+  <!-- Include preview Blazor bits -->
+  <PropertyGroup>
+    <RestoreAdditionalProjectSources>
+      https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
+      https://www.myget.org/F/blazor-experiments/api/v3/index.json;
+    </RestoreAdditionalProjectSources>
+  </PropertyGroup>
 </Project>

--- a/src/Blazor.Extensions.Storage.JS/Blazor.Extensions.Storage.JS.csproj
+++ b/src/Blazor.Extensions.Storage.JS/Blazor.Extensions.Storage.JS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="0.8.0-preview1-20181126.4" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/Blazor.Extensions.Storage/Blazor.Extensions.Storage.csproj
+++ b/src/Blazor.Extensions.Storage/Blazor.Extensions.Storage.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>Blazor Extensions Storage</Title>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="0.8.0-preview1-20181126.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Blazor.Extensions.Storage.Test/Blazor.Extensions.Storage.Test.csproj
+++ b/test/Blazor.Extensions.Storage.Test/Blazor.Extensions.Storage.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <RunCommand>dotnet</RunCommand>
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Extensions.Logging" Version="0.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
-    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.7.0" />
+    <PackageReference Include="Blazor.Extensions.Logging" Version="0.1.11-preview1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="0.8.0-preview1-20181126.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="0.8.0-preview1-20181126.4" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.8.0-preview1-20181126.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Blazor.Extensions.Storage.Test/Program.cs
+++ b/test/Blazor.Extensions.Storage.Test/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Blazor.Hosting;
+using Microsoft.AspNetCore.Components.Hosting;
 
 namespace Blazor.Extensions.Storage.Test
 {

--- a/test/Blazor.Extensions.Storage.Test/Shared/MainLayout.cshtml
+++ b/test/Blazor.Extensions.Storage.Test/Shared/MainLayout.cshtml
@@ -1,4 +1,4 @@
-@inherits BlazorLayoutComponent
+@inherits LayoutComponentBase
 
 <div>
     @Body

--- a/test/Blazor.Extensions.Storage.Test/Startup.cs
+++ b/test/Blazor.Extensions.Storage.Test/Startup.cs
@@ -1,5 +1,5 @@
 using Blazor.Extensions.Logging;
-using Microsoft.AspNetCore.Blazor.Builder;
+using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/test/Blazor.Extensions.Storage.Test/_ViewImports.cshtml
+++ b/test/Blazor.Extensions.Storage.Test/_ViewImports.cshtml
@@ -1,8 +1,6 @@
 @using System.Net.Http
-@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
-@using Microsoft.AspNetCore.Blazor.Layouts
-@using Microsoft.AspNetCore.Blazor.Routing
+@using Microsoft.AspNetCore.Components.Layouts
+@using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.Extensions.Logging
 @using Blazor.Extensions.Storage
 @using Blazor.Extensions.Storage.Test


### PR DESCRIPTION
This is work required to make Logging extension work with Blazor 0.8.0 preview which is hybrid version between original Blazor and Razor Components based Blazor

This is change for informational purposes only, to serve as sample for those who want to try 0.8.0-preview bits of Blazor

I order to use pre-compiled version of this PR, you could add to you project file
```
  <PropertyGroup>
    <RestoreAdditionalProjectSources>
      https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
      https://www.myget.org/F/blazor-experiments/api/v3/index.json;
    </RestoreAdditionalProjectSources>
  </PropertyGroup>
```

Nuget was created using `dotnet pack Blazor.Extensions.Storage.csproj /p:Version=0.1.8-preview1 /p:Configuration=Release` to those who want to create package manually from branch