### PR TITLE
Updated to Blazor 0.9.0

### DIFF
--- a/src/Blazor.Extensions.Storage.JS/Blazor.Extensions.Storage.JS.csproj
+++ b/src/Blazor.Extensions.Storage.JS/Blazor.Extensions.Storage.JS.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="3.0.0-preview3-19153-02" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/Blazor.Extensions.Storage/Blazor.Extensions.Storage.csproj
+++ b/src/Blazor.Extensions.Storage/Blazor.Extensions.Storage.csproj
@@ -8,10 +8,13 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0-preview3.19153.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blazor.Extensions.Storage/Blazor.Extensions.Storage.csproj
+++ b/src/Blazor.Extensions.Storage/Blazor.Extensions.Storage.csproj
@@ -8,7 +8,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>
-    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Blazor.Extensions.Storage/LocalStorage.cs
+++ b/src/Blazor.Extensions.Storage/LocalStorage.cs
@@ -7,30 +7,37 @@ namespace Blazor.Extensions.Storage
 {
     public class LocalStorage : IStorage
     {
-        public Task<int> Length() => JSRuntime.Current.InvokeAsync<int>(MethodNames.LENGTH_METHOD, StorageTypeNames.LOCAL_STORAGE);
-        public Task Clear() => JSRuntime.Current.InvokeAsync<object>(MethodNames.CLEAR_METHOD, StorageTypeNames.LOCAL_STORAGE);
+        IJSRuntime jsRuntime;
+
+        public LocalStorage(IJSRuntime jsRuntime)
+        {
+            this.jsRuntime = jsRuntime;
+        }
+
+        public Task<int> Length() => this.jsRuntime.InvokeAsync<int>(MethodNames.LENGTH_METHOD, StorageTypeNames.LOCAL_STORAGE);
+        public Task Clear() => this.jsRuntime.InvokeAsync<object>(MethodNames.CLEAR_METHOD, StorageTypeNames.LOCAL_STORAGE);
 
         public Task<TItem> GetItem<TItem>(string key)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException(nameof(key));
 
-            return JSRuntime.Current.InvokeAsync<TItem>(MethodNames.GET_ITEM_METHOD, StorageTypeNames.LOCAL_STORAGE, key);
+            return this.jsRuntime.InvokeAsync<TItem>(MethodNames.GET_ITEM_METHOD, StorageTypeNames.LOCAL_STORAGE, key);
         }
 
-        public Task<string> Key(int index) => JSRuntime.Current.InvokeAsync<string>(MethodNames.KEY_METHOD, StorageTypeNames.LOCAL_STORAGE, index);
+        public Task<string> Key(int index) => this.jsRuntime.InvokeAsync<string>(MethodNames.KEY_METHOD, StorageTypeNames.LOCAL_STORAGE, index);
 
         public Task RemoveItem(string key)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException(nameof(key));
 
-            return JSRuntime.Current.InvokeAsync<object>(MethodNames.REMOVE_ITEM_METHOD, StorageTypeNames.LOCAL_STORAGE, key);
+            return this.jsRuntime.InvokeAsync<object>(MethodNames.REMOVE_ITEM_METHOD, StorageTypeNames.LOCAL_STORAGE, key);
         }
 
         public Task SetItem<TItem>(string key, TItem item)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException(nameof(key));
 
-            return JSRuntime.Current.InvokeAsync<object>(MethodNames.SET_ITEM_METHOD, StorageTypeNames.LOCAL_STORAGE, key, item);
+            return this.jsRuntime.InvokeAsync<object>(MethodNames.SET_ITEM_METHOD, StorageTypeNames.LOCAL_STORAGE, key, item);
         }
     }
 }

--- a/src/Blazor.Extensions.Storage/SessionStorage.cs
+++ b/src/Blazor.Extensions.Storage/SessionStorage.cs
@@ -7,30 +7,37 @@ namespace Blazor.Extensions.Storage
 {
     public class SessionStorage : IStorage
     {
-        public Task<int> Length() => JSRuntime.Current.InvokeAsync<int>(MethodNames.LENGTH_METHOD, StorageTypeNames.SESSION_STORAGE);
-        public Task Clear() => JSRuntime.Current.InvokeAsync<object>(MethodNames.CLEAR_METHOD, StorageTypeNames.SESSION_STORAGE);
+        IJSRuntime jsRuntime;
+
+        public SessionStorage(IJSRuntime jsRuntime)
+        {
+            this.jsRuntime = jsRuntime;
+        }
+
+        public Task<int> Length() => this.jsRuntime.InvokeAsync<int>(MethodNames.LENGTH_METHOD, StorageTypeNames.SESSION_STORAGE);
+        public Task Clear() => this.jsRuntime.InvokeAsync<object>(MethodNames.CLEAR_METHOD, StorageTypeNames.SESSION_STORAGE);
 
         public Task<TItem> GetItem<TItem>(string key)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException(nameof(key));
 
-            return JSRuntime.Current.InvokeAsync<TItem>(MethodNames.GET_ITEM_METHOD, StorageTypeNames.SESSION_STORAGE, key);
+            return this.jsRuntime.InvokeAsync<TItem>(MethodNames.GET_ITEM_METHOD, StorageTypeNames.SESSION_STORAGE, key);
         }
 
-        public Task<string> Key(int index) => JSRuntime.Current.InvokeAsync<string>(MethodNames.KEY_METHOD, StorageTypeNames.SESSION_STORAGE, index);
+        public Task<string> Key(int index) => this.jsRuntime.InvokeAsync<string>(MethodNames.KEY_METHOD, StorageTypeNames.SESSION_STORAGE, index);
 
         public Task RemoveItem(string key)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException(nameof(key));
 
-            return JSRuntime.Current.InvokeAsync<object>(MethodNames.REMOVE_ITEM_METHOD, StorageTypeNames.SESSION_STORAGE, key);
+            return this.jsRuntime.InvokeAsync<object>(MethodNames.REMOVE_ITEM_METHOD, StorageTypeNames.SESSION_STORAGE, key);
         }
 
         public Task SetItem<TItem>(string key, TItem item)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException(nameof(key));
 
-            return JSRuntime.Current.InvokeAsync<TItem>(MethodNames.SET_ITEM_METHOD, StorageTypeNames.SESSION_STORAGE, key, item);
+            return this.jsRuntime.InvokeAsync<TItem>(MethodNames.SET_ITEM_METHOD, StorageTypeNames.SESSION_STORAGE, key, item);
         }
     }
 }

--- a/test/Blazor.Extensions.Storage.Test/Blazor.Extensions.Storage.Test.csproj
+++ b/test/Blazor.Extensions.Storage.Test/Blazor.Extensions.Storage.Test.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.9.0-preview3-19154-02" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.9.0-preview3-19154-02" />
-    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.8.0-preview1-20181126.4" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.9.0-preview3-19154-02" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Blazor.Extensions.Storage.Test/Blazor.Extensions.Storage.Test.csproj
+++ b/test/Blazor.Extensions.Storage.Test/Blazor.Extensions.Storage.Test.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Extensions.Logging" Version="0.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
-    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.9.0-preview3-19154-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.9.0-preview3-19154-02" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.8.0-preview1-20181126.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Blazor.Extensions.Storage.Test/Interop/InteropStorage.cs
+++ b/test/Blazor.Extensions.Storage.Test/Interop/InteropStorage.cs
@@ -8,6 +8,17 @@ namespace Blazor.Extensions.Storage.Test.Interop
     /// </summary>
     public class InteropStorage
     {
+        private IJSRuntime jsRuntime;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="js">Reference to the js runtime.</param>
+        public InteropStorage(IJSRuntime js)
+        {
+            this.jsRuntime = js;
+        }
+
         /// <summary>
         /// Returns a session storage value.
         /// </summary>
@@ -15,7 +26,7 @@ namespace Blazor.Extensions.Storage.Test.Interop
         /// <returns>Task that returns the stored value as a string.</returns>
         public async Task<string> GetSessionStorage(string key)
         {
-            return await JSRuntime.Current.InvokeAsync<string>(
+            return await this.jsRuntime.InvokeAsync<string>(
                 "getSessionStorage",
                 key
             );
@@ -28,7 +39,7 @@ namespace Blazor.Extensions.Storage.Test.Interop
         /// <returns>Task that returns the stored value as a string.</returns>
         public async Task<string> GetLocalStorage(string key)
         {
-            return await JSRuntime.Current.InvokeAsync<string>(
+            return await this.jsRuntime.InvokeAsync<string>(
                 "getLocalStorage",
                 key
             );

--- a/test/Blazor.Extensions.Storage.Test/Pages/Index.cshtml
+++ b/test/Blazor.Extensions.Storage.Test/Pages/Index.cshtml
@@ -2,16 +2,19 @@
 @inject SessionStorage SessionStorage
 @inject LocalStorage LocalStorage
 @inject HttpClient Http
-@inject ILogger<Index> logger
-@using Blazor.Extensions.Storage.Test.Interop
+
+@inject IJSRuntime  js;
+@using Blazor.Extensions.Storage.Test.Interop;
+@using Microsoft.JSInterop;
 
 <h1>Session and Local Storage Test, Open up your browser devtools to see the logs!</h1>
 @functions {
     private WeatherForecast[] forecasts;
-    private readonly InteropStorage interopStorage = new InteropStorage();
+    private InteropStorage interopStorage;
 
     protected override async Task OnInitAsync()
     {
+        interopStorage = new InteropStorage(js);
         forecasts = (await Http.GetJsonAsync<WeatherForecast[]>("/weather.json"));
         var key = "forecasts";
         try
@@ -25,33 +28,35 @@
             var iopSessionHasQuotes = fromIopSession.StartsWith("\"") || fromIopSession.EndsWith("\"");
             var iopLocalHasQuotes = fromIopLocal.StartsWith("\"") || fromIopLocal.EndsWith("\"");
 
-            logger.LogInformation($"Interop get from session storage contains extra quotes: {iopSessionHasQuotes}");
-            logger.LogInformation(fromIopSession);
-            logger.LogInformation($"Interop get from local storage contains extra quotes: {iopLocalHasQuotes}");
-            logger.LogInformation(fromIopLocal);
+            Console.WriteLine($"Interop get from session storage contains extra quotes: {iopSessionHasQuotes}");
+            Console.WriteLine(fromIopSession);
+            Console.WriteLine($"Interop get from local storage contains extra quotes: {iopLocalHasQuotes}");
+            Console.WriteLine(fromIopLocal);
 
             var fromSession = await SessionStorage.GetItem<WeatherForecast[]>(key);
             var fromLocal = await LocalStorage.GetItem<WeatherForecast[]>(key);
 
-            logger.LogInformation("From session storage:");
-            logger.LogInformation(fromSession);
-            logger.LogInformation("From local storage:");
-            logger.LogInformation(fromLocal);
+            Console.WriteLine("From session storage:");
+            Console.WriteLine(Json.Serialize(fromSession));
+            Console.WriteLine("From local storage:");
+            Console.WriteLine(Json.Serialize(fromLocal));
 
-            logger.LogInformation($"Total in session: {await SessionStorage.Length()}");
-            logger.LogInformation($"Total in local: {await LocalStorage.Length()}");
+           
 
-            logger.LogInformation("Removing from session storage...");
+            Console.WriteLine($"Total in session: {await SessionStorage.Length()}");
+            Console.WriteLine($"Total in local: {await LocalStorage.Length()}");
+
+            Console.WriteLine("Removing from session storage...");
             await SessionStorage.RemoveItem(key);
-            logger.LogInformation("Removing from local storage...");
+            Console.WriteLine("Removing from local storage...");
             await LocalStorage.RemoveItem(key);
 
-            logger.LogInformation($"Total in session: {await SessionStorage.Length()}");
-            logger.LogInformation($"Total in local: {await SessionStorage.Length()}");
+            Console.WriteLine($"Total in session: {await SessionStorage.Length()}");
+            Console.WriteLine($"Total in local: {await SessionStorage.Length()}");
         }
         catch (Exception ex)
         {
-            logger.LogError(ex);
+             Console.WriteLine(ex.Message);
 
         }
     }

--- a/test/Blazor.Extensions.Storage.Test/Shared/MainLayout.cshtml
+++ b/test/Blazor.Extensions.Storage.Test/Shared/MainLayout.cshtml
@@ -1,4 +1,4 @@
-@inherits BlazorLayoutComponent
+@inherits LayoutComponentBase
 
 <div>
     @Body

--- a/test/Blazor.Extensions.Storage.Test/Startup.cs
+++ b/test/Blazor.Extensions.Storage.Test/Startup.cs
@@ -1,7 +1,5 @@
-using Blazor.Extensions.Logging;
-using Microsoft.AspNetCore.Blazor.Builder;
+using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Blazor.Extensions.Storage.Test
 {
@@ -11,14 +9,9 @@ namespace Blazor.Extensions.Storage.Test
         {
             //Add Blazor.Extensions.Storage
             services.AddStorage();
-
-            services.AddLogging(builder => builder
-                .AddBrowserConsole()
-                .SetMinimumLevel(LogLevel.Trace)
-            );
         }
 
-        public void Configure(IBlazorApplicationBuilder app)
+        public void Configure(IComponentsApplicationBuilder app)
         {
             app.AddComponent<App>("app");
         }

--- a/test/Blazor.Extensions.Storage.Test/_ViewImports.cshtml
+++ b/test/Blazor.Extensions.Storage.Test/_ViewImports.cshtml
@@ -1,10 +1,6 @@
 @using System.Net.Http
-@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
-@using Microsoft.AspNetCore.Blazor.Layouts
-@using Microsoft.AspNetCore.Blazor.Routing
-@using Microsoft.Extensions.Logging
+@using Microsoft.AspNetCore.Components.Layouts
+@using Microsoft.AspNetCore.Components.Routing
 @using Blazor.Extensions.Storage
 @using Blazor.Extensions.Storage.Test
 @using Blazor.Extensions.Storage.Test.Shared
-@using Blazor.Extensions.Logging

--- a/test/Blazor.Extensions.Storage.Test/wwwroot/index.html
+++ b/test/Blazor.Extensions.Storage.Test/wwwroot/index.html
@@ -9,7 +9,7 @@
 <body>
   <app>Loading...</app>
 
-  <script src="_framework/blazor.webassembly.js"></script>
+  <script src="_framework/components.webassembly.js"></script>
   <script type="text/javascript">
 
     function getLocalStorage(key) {


### PR DESCRIPTION
Updated all references to use 0.9.0 of Blazor components and made any required changes to support that version. 

Removed Blazor extensions logging dependency in the test project to allow testing without updating the logging to 0.9.0. I have used Console.WriteLine() instead.